### PR TITLE
Implemented basic tile grid generation

### DIFF
--- a/Unity/CS380 Game AI Research Project/.vsconfig
+++ b/Unity/CS380 Game AI Research Project/.vsconfig
@@ -1,0 +1,6 @@
+﻿{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapGenerator.prefab
+++ b/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapGenerator.prefab
@@ -1,0 +1,62 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &575335195362193090
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 575335195362193084}
+  - component: {fileID: 575335195362193091}
+  - component: {fileID: 575335195362193085}
+  m_Layer: 0
+  m_Name: MapGenerator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &575335195362193084
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575335195362193090}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &575335195362193091
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575335195362193090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d38a223b818acad4297f6ea8f1b6bea8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  width: 10
+  height: 10
+--- !u!114 &575335195362193085
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 575335195362193090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d53e879ba99a19d4886e2d8c4de9f43b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TilePrefab: {fileID: 1348247329763496945, guid: e0508a3d2319b2d4bb7a3e1afcb81881, type: 3}

--- a/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapGenerator.prefab.meta
+++ b/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapGenerator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 57e1a0089643e8243937051e0b5fb043
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapTile.prefab
+++ b/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapTile.prefab
@@ -1,0 +1,144 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1348247329763496945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2047318566556798160}
+  - component: {fileID: 2366733069124943710}
+  - component: {fileID: 553404302346638062}
+  - component: {fileID: 587761237446413743}
+  - component: {fileID: 3270118930228856296}
+  m_Layer: 0
+  m_Name: MapTile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2047318566556798160
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1348247329763496945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2366733069124943710
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1348247329763496945}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &553404302346638062
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1348247329763496945}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &587761237446413743
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1348247329763496945}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &3270118930228856296
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1348247329763496945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 171aa72ee9cc06b4197252b1c9ee5cc1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  X: 0
+  Y: 0
+  Value: 0
+  valueGrad:
+    serializedVersion: 2
+    key0: {r: 1, g: 0.15558341, b: 0, a: 1}
+    key1: {r: 0, g: 0.8827014, b: 1, a: 1}
+    key2: {r: 0, g: 0, b: 0, a: 0}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 65535
+    ctime2: 0
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 2
+    m_NumAlphaKeys: 2

--- a/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapTile.prefab.meta
+++ b/Unity/CS380 Game AI Research Project/Assets/Prefabs/MapTile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0508a3d2319b2d4bb7a3e1afcb81881
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/CS380 Game AI Research Project/Assets/Scenes/SampleScene.unity
+++ b/Unity/CS380 Game AI Research Project/Assets/Scenes/SampleScene.unity
@@ -301,63 +301,63 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &2219179884677619276
+--- !u!1001 &575335194729087868
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.52
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.6700001
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.48
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1723289157392008830, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193084, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4804486458947462676, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+    - target: {fileID: 575335195362193090, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
       propertyPath: m_Name
-      value: Obstacle
+      value: MapGenerator
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9394a13ab15edf5458ebe6a4c8753abf, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 57e1a0089643e8243937051e0b5fb043, type: 3}
 --- !u!1001 &2987652251494481432
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -415,60 +415,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 49c169ccb91ac9d4fbaea3791b5174b1, type: 3}
---- !u!1001 &4252671265410988956
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434145, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252671264283434149, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}
-      propertyPath: m_Name
-      value: Map
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2308ea207f169f44aa1bf11d80ddde7f, type: 3}

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/GenericSingleton.cs
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/GenericSingleton.cs
@@ -1,0 +1,28 @@
+// http://www.unitygeek.com/unity_c_singleton/
+using UnityEngine;
+
+public class GenericSingletonClass<T> : MonoBehaviour where T : Component {
+  private static T instance;
+  public static T Instance {
+    get {
+      if (instance == null) {
+        instance = FindObjectOfType<T> ();
+        if (instance == null) {
+          GameObject obj = new GameObject();
+          obj.name = typeof(T).Name;
+          instance = obj.AddComponent<T>();
+        }
+      }
+      return instance;
+    }
+  }
+
+  public virtual void Awake () {
+    if (instance == null) {
+      instance = this as T;
+      DontDestroyOnLoad (this.gameObject);
+    } else {
+      Destroy (gameObject);
+    }
+  }
+}

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/GenericSingleton.cs.meta
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/GenericSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac35ee2d5ba735d41b2b5876447ace7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/MapGen.cs
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/MapGen.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MapGen : MonoBehaviour
+{
+    // dimensions of map generated (tiles)
+    public uint width = 10, height = 10;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        Generate();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    public void Generate() {
+        MapManager.Instance.SetSize(width, height);
+    }
+}

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/MapGen.cs.meta
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/MapGen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d38a223b818acad4297f6ea8f1b6bea8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/MapManager.cs
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/MapManager.cs
@@ -1,0 +1,82 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MapManager : GenericSingletonClass<MapManager>
+{
+    [SerializeReference]
+    public GameObject TilePrefab;
+
+    public List<List<GameObject>> tiles = null;
+
+    private void DestroyTiles()
+    {
+        // free previous grid
+        for (int i = 0; i < tiles.Count; ++i)
+        {
+            for (int j = 0; j < tiles[i].Count; ++j)
+            {
+                Destroy(tiles[i][j]);
+            }
+            tiles[i].Clear();
+        }
+
+        tiles.Clear();
+    }
+
+    private void PlaceTiles(uint width, uint height)
+    {
+        Vector2 TileDims = new Vector2(TilePrefab.transform.localScale.x, TilePrefab.transform.localScale.z);
+
+        // instantiate new tiles, apply position offset.
+        for (int i = 0; i < height; ++i)
+        {
+            // establish new row
+            tiles.Add(new List<GameObject>());
+            for (int j = 0; j < width; ++j)
+            {
+                // instantiate prefab
+                GameObject obj = Instantiate(TilePrefab);
+                obj.transform.position = new Vector3(TileDims.y * i, 0.0f, TileDims.x * j);
+
+                // set MapTile data.
+                MapTile mt = obj.GetComponent<MapTile>();
+                mt.SetXY((uint)j, (uint)i);
+                // VALUE RANDOMIZER FOR TEMPORARY USE
+                mt.SetValue(Random.Range(-1.0f, 1.0f));
+
+                // add to tiles                    
+                tiles[i].Add(obj);
+            }
+        }
+    }
+
+    private void Alloc(uint width, uint height)
+    {
+        if (tiles == null)
+        {
+            tiles = new List<List<GameObject>>();
+        }
+        else
+        {
+            DestroyTiles();
+        }
+
+        PlaceTiles(width, height);
+    }
+
+    public void SetSize(uint width, uint height)
+    {
+        if (tiles == null)
+        {
+            Alloc(width, height);
+            return;
+        }
+
+        // reallocate to fit new size.
+        if (height != tiles.Count && width != tiles[0].Count)
+        {
+            Alloc(width, height);
+        }
+    }
+}

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/MapManager.cs.meta
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/MapManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d53e879ba99a19d4886e2d8c4de9f43b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - TilePrefab: {fileID: 1348247329763496945, guid: e0508a3d2319b2d4bb7a3e1afcb81881, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/MapTile.cs
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/MapTile.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+public class MapTile : MonoBehaviour
+{
+    public uint X, Y;
+
+    [Range(-1.0f, 1.0f)]
+    public float Value = 1.0f;
+    bool valueDirty = true;
+
+    [Header("Visualizer")]
+    public Gradient valueGrad;
+
+
+    void LateUpdate()
+    {
+        // set color for visualization
+        if (valueDirty == true)
+        {
+            gameObject.GetComponent<Renderer>().materials[0].SetColor("_Color", valueGrad.Evaluate((Value - (-1.0f)) / 2.0f));
+        } 
+    }
+
+    public void SetXY(uint x, uint y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public void SetValue(float value)
+    {
+        Value = value;
+    }
+}

--- a/Unity/CS380 Game AI Research Project/Assets/Scripts/MapTile.cs.meta
+++ b/Unity/CS380 Game AI Research Project/Assets/Scripts/MapTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 171aa72ee9cc06b4197252b1c9ee5cc1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44276485/177411299-9e47fe91-5d4b-45a1-9006-f70ea7a53d53.png)

* Implemented simple parameter based tiling of prefabs.
* Implemented simple random and visualizer for tile values.
`(red for low, blue for high (-1 to 1 range))`

Most parameters are configurable in relevant components on prefabs.

## notes

MapGen will eventually be used to configure the map generation parameters.  At this moment it only allows configuration of map size.

MapTile Prefab is set on the MapManager.cs component

MapTile.cs component is used to store information about each tile.  It should be included on any prefab that is used as a tile.

Prefabs are spawned such that they don't overlap, and have no space between them.

MapGenerator.prefab contains the components which call the map generation functions.
